### PR TITLE
Parse Steam nickname

### DIFF
--- a/lib/import_profile_screen.dart
+++ b/lib/import_profile_screen.dart
@@ -37,6 +37,7 @@ class _ImportProfileScreenState extends State<ImportProfileScreen> {
       final pr = await http.get(profileUrl);
       if (pr.statusCode != 200) throw loc.steam_profile_not_found;
       final docP = XmlDocument.parse(pr.body);
+      _steamNick = docP.findAllElements('steamID').first.text;
       final steamID = docP.findAllElements('steamID64').first.text;
       final gamesUrl = Uri.parse('https://steamcommunity.com/profiles/$steamID/games?xml=1');
       final gr = await http.get(gamesUrl);
@@ -50,7 +51,7 @@ class _ImportProfileScreenState extends State<ImportProfileScreen> {
       await prefs.setString('importedGames', jsonEncode(parsed));
       await prefs.setString('lastImportProfile', input); // Запомнили последний профиль
       await prefs.setString('lastImportTime', DateTime.now().toIso8601String());
-      await prefs.setString('importedSteamNick', _steamNick ?? '');
+      await prefs.setString('importedSteamNick', _steamNick!);
       if (!mounted) return;
       Navigator.pop(context, true);
     } catch (e) {


### PR DESCRIPTION
## Summary
- capture user's Steam nickname from the imported profile XML
- store the nickname in SharedPreferences when saving import data

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d8e04df88320bbb78075b8eba211